### PR TITLE
fix SSL connection error (dh key too small)

### DIFF
--- a/lib/Web/NewsAPI.pm
+++ b/lib/Web/NewsAPI.pm
@@ -113,6 +113,9 @@ sub _build_ua {
     my $self = shift;
 
     my $ua = LWP::UserAgent->new;
+    $ua->ssl_opts(
+        SSL_version => 'TLSv1_2',
+    );
     $ua->default_header(
         'X-Api-Key' => $self->api_key,
     );


### PR DESCRIPTION
newsapi.org only supports TLS 1.2. Without specifying the protocol (SSL_Version) LWP / IO::Socket::SSL fails on connection with following message.

_News API responded with an error (500): Can't connect to newsapi.org:443 (SSL connect attempt failed error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small)_

This commit forces the use of TLS 1.2 to avoid the connection abortion.
